### PR TITLE
Update setup.py to specify MPI compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ class cmake_build_ext(build_ext.build_ext):
                 "-DPYTHON_EXECUTABLE={}".format(sys.executable),
                 # Add other project-specific CMake arguments if needed
                 # ...
+                "-DCMAKE_C_COMPILER={}".format("mpicc"),
+                "-DCMAKE_CXX_COMPILER={}".format("mpicxx"),
             ]
 
             # We can handle some platform-specific settings at our discretion


### PR DESCRIPTION
I think directly providing mpi-compiler would help correctly locate the `mpi.h` file, especially when the machine has a mixture of mpi and non-mpi compilers. I found this very helpful in installing this package on clusters.