### PR TITLE
Update setup.py to include MPI compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ To build the python module:
 ```
 git clone https://github.com/iraikov/neuroh5.git
 cd neuroh5
-CMAKE_BUILD_PARALLEL_LEVEL=8 pip install .
+CMAKE_BUILD_PARALLEL_LEVEL=8 \
+  CMAKE_MPI_C_COMPILER=$(which mpicc) \
+  CMAKE_MPI_CXX_COMPILER=$(which mpicxx) \
+  pip install .
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ class cmake_build_ext(build_ext.build_ext):
                 "-DPYTHON_EXECUTABLE={}".format(sys.executable),
                 # Add other project-specific CMake arguments if needed
                 # ...
+                "-DCMAKE_C_COMPILER={}".format("mpicc"),
+                "-DCMAKE_CXX_COMPILER={}".format("mpicxx"),
             ]
 
             # We can handle some platform-specific settings at our discretion

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ class cmake_build_ext(build_ext.build_ext):
                 "-DPYTHON_EXECUTABLE={}".format(sys.executable),
                 # Add other project-specific CMake arguments if needed
                 # ...
-                "-DCMAKE_C_COMPILER={}".format("mpicc"),
-                "-DCMAKE_CXX_COMPILER={}".format("mpicxx"),
             ]
 
             # We can handle some platform-specific settings at our discretion


### PR DESCRIPTION
I think directly providing mpi-compiler would help correctly locate the mpi.h file, especially when the machine has a mixture of mpi and non-mpi compilers. I found this very helpful in installing this package on clusters.