### PR TITLE
Update setup.py: change `entry_point` in dictionary form

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,13 +145,14 @@ setup(
     long_description_content_type='text/markdown',
     url="http://github.com/iraikov/neuroh5",
     include_package_data=True,
-    entry_points="""
-        [console_scripts]
-        initrange=neuroh5.initrange:cli
-        initprj=neuroh5.initprj:cli
-        importdbs=neuroh5.importdbs:cli
-        importcoords=neuroh5.importcoords:cli
-    """,
+    entry_points={
+        "console_scripts": [
+            'initrange=neuroh5.initrange:cli',
+            'initprj=neuroh5.initprj:cli',
+            'importdbs=neuroh5.importdbs:cli',
+            'importcoords=neuroh5.importcoords:cli',
+        ]
+    },
     cmdclass={"build_ext": cmake_build_ext},
     ext_modules=[CMakeExtension("neuroh5.io", target="python_neuroh5_io")],
 )


### PR DESCRIPTION
## Description

There have been some changes in how the `entry_point` is parsed: [link](https://github.com/pypa/setuptools/blob/245d72a8aa4d47e1811425213aba2a06a0bb64fa/setuptools/config/_apply_pyprojecttoml.py#L282-L285).

The issue might be a momentary thing in `setuptools`, but I think it is a general trend to use dictionary format as they integrate `.toml` stuff.

As a result, I'm getting the following error while building wheel for `neuroh5`. (Using `setuptools`==67.6.1, `python`=3.9.2)
<details>
  <summary>Click to expand</summary>

```sh
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [39 lines of output]
      Traceback (most recent call last):
        File "/home1/08326/tg876254/MiV-Install/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home1/08326/tg876254/MiV-Install/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home1/08326/tg876254/MiV-Install/venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 136, in <module>
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 159, in setup
          dist.parse_config_files()
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 885, in parse_config_files
          pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 62, in apply_configuration
          config = read_configuration(filepath, True, ignore_option_errors, dist)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 140, in read_configuration
          return expand_configuration(asdict, root_dir, ignore_option_errors, dist)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 195, in expand_configuration
          return _ConfigExpander(config, root_dir, ignore_option_errors, dist).expand()
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 243, in expand
          self._expand_all_dynamic(dist, package_dir)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 287, in _expand_all_dynamic
          self._obtain_entry_points(dist, package_dir) or {},
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 361, in _obtain_entry_points
          text = self._obtain(dist, "entry-points", package_dir)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 331, in _obtain
          self._ensure_previously_set(dist, field)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 300, in _ensure_previously_set
          previous = _PREVIOUSLY_DEFINED[field](dist)
        File "/tmp/pip-build-env-_kfsf2wa/overlay/lib/python3.9/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 285, in _get_previous_entrypoints
          return {k: v for k, v in value.items() if k not in ignore}
      AttributeError: 'str' object has no attribute 'items'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output
```
</details>

## Changes

I'm pushing a simple fix, which replaces the string format with dictionary format.