### PR TITLE
Use signed int to handle getopt_long correctly

### DIFF
--- a/src/driver/balance_indegree.cc
+++ b/src/driver/balance_indegree.cc
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
     {"iosize",    required_argument, &optflag_iosize,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "hi:n:o:",
 			   long_options, &option_index)) != -1)

--- a/src/driver/neurograph_import.cc
+++ b/src/driver/neurograph_import.cc
@@ -326,7 +326,7 @@ int main(int argc, char** argv)
     {"attributes",    required_argument, &optflag_attr_names,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "a:d:f:hi:s:", long_options, &option_index)) != -1)
     {

--- a/src/driver/neurograph_parts.cc
+++ b/src/driver/neurograph_parts.cc
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
     {"iosize",    required_argument, &optflag_iosize,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "hi:n:o:",
 			   long_options, &option_index)) != -1)

--- a/src/driver/neurograph_reader.cc
+++ b/src/driver/neurograph_reader.cc
@@ -146,7 +146,7 @@ int main(int argc, char** argv)
     {"verbose",  no_argument, &optflag_verbose,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "ahs",
                            long_options, &option_index)) != -1)

--- a/src/driver/neurograph_scatter_read.cc
+++ b/src/driver/neurograph_scatter_read.cc
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
     {"edgemap",   required_argument, &optflag_edgemap,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "a:be:o:r:i:h",
                            long_options, &option_index)) != -1)

--- a/src/driver/neurotrees_copy.cc
+++ b/src/driver/neurotrees_copy.cc
@@ -127,7 +127,7 @@ int main(int argc, char** argv)
     {"value-chunk-size",  required_argument, &optflag_value_chunk_size,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "haow:", long_options, &option_index)) != -1)
     {

--- a/src/driver/neurotrees_import.cc
+++ b/src/driver/neurotrees_import.cc
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
   static struct option long_options[] = {
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "hd:e:i:o:r:t:l:n:sy:", long_options, &option_index)) != -1)
     {

--- a/src/driver/neurotrees_read.cc
+++ b/src/driver/neurotrees_read.cc
@@ -167,7 +167,7 @@ int main(int argc, char** argv)
     {"verbose",  no_argument, &optflag_verbose,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "h",
                            long_options, &option_index)) != -1)

--- a/src/driver/neurotrees_scatter_read.cc
+++ b/src/driver/neurotrees_scatter_read.cc
@@ -273,7 +273,7 @@ int main(int argc, char** argv)
     {"namespace", required_argument, &optflag_namespace,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "ar:i:n:oh",
                            long_options, &option_index)) != -1)

--- a/src/driver/neurotrees_select.cc
+++ b/src/driver/neurotrees_select.cc
@@ -155,7 +155,7 @@ int main(int argc, char** argv)
     {"cachesize", required_argument, &optflag_cachesize,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "ai:p:r:n:oh",
                            long_options, &option_index)) != -1)

--- a/src/driver/vertex_metrics.cc
+++ b/src/driver/vertex_metrics.cc
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
     {"outdegree", no_argument, &optflag_outdegree,  1 },
     {0,         0,                 0,  0 }
   };
-  char c;
+  int c;
   int option_index = 0;
   while ((c = getopt_long (argc, argv, "hi:o:",
                            long_options, &option_index)) != -1)


### PR DESCRIPTION
Unlike on x86, `char` can be unsigned by default on ARM systems like TACC Vista. So when `getopt_long()` returns -1 for indicating end of options, the `char c = -1` can end up as 255. This fix addresses the problem by changing the dtype to int which is always signed int on all platforms.