### PR TITLE
Ensure correct MPI linking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy >= 1.21.6", "mpi4py >= 3.0.0",]
+requires = ["setuptools", "wheel", "numpy >= 1.21.6", "mpi4py >= 3.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "neuroh5"
 dynamic = ["version", "description", "entry-points", "maintainers", "readme"]
-dependencies = [
-  "click",
-  "h5py >= 3.0",
-  "numpy >= 1.21.6",
-  "mpi4py >= 3.0.0",
-]
+dependencies = ["click", "h5py >= 3.0", "numpy >= 1.21.6", "mpi4py >= 3.0.0"]
+
+[tool.uv]
+no-binary-package = ["mpi4py"]
+
+[tool.uv.pip]
+no-binary = ["mpi4py"]

--- a/python/neuroh5/CMakeLists.txt
+++ b/python/neuroh5/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(
     PROPERTIES
         PREFIX ""
         OUTPUT_NAME ${NEUROH5_IO_PYTHON_C_MODULE_NAME}
-        LINKER_LANGUAGE CXX
+        LINKER_LANGUAGE C
 )
 
 

--- a/python/neuroh5/CMakeLists.txt
+++ b/python/neuroh5/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(
     PROPERTIES
         PREFIX ""
         OUTPUT_NAME ${NEUROH5_IO_PYTHON_C_MODULE_NAME}
-        LINKER_LANGUAGE C
+        LINKER_LANGUAGE CXX
 )
 
 


### PR DESCRIPTION
This instructs uv to ignore prebuild mpi4py binaries to ensure proper linking against the available MPI version. 