### PR TITLE
Fix tuple template syntax in cereal library so clang can build

### DIFF
--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -12,14 +12,14 @@
       * Redistributions in binary form must reproduce the above copyright
         notice, this list of conditions and the following disclaimer in the
         documentation and/or other materials provided with the distribution.
-      * Neither the name of cereal nor the
+      * Neither the name of the copyright holder nor the
         names of its contributors may be used to endorse or promote products
         derived from this software without specific prior written permission.
 
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES OR SHANE GRANT BE LIABLE FOR ANY
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
@@ -38,7 +38,7 @@ namespace cereal
   namespace tuple_detail
   {
     //! Creates a c string from a sequence of characters
-    /*! The c string created will alwas be prefixed by "tuple_element"
+    /*! The c string created will always be prefixed by "tuple_element"
         Based on code from: http://stackoverflow/a/20973438/710791
         @internal */
     template<char...Cs>
@@ -63,7 +63,7 @@ namespace cereal
     template <size_t Q, size_t R, char ... C>
     struct to_string_impl
     {
-      using type = typename to_string_impl<Q/10, Q%10, R+'0', C...>::type;
+      using type = typename to_string_impl<Q/10, Q%10, static_cast<char>(R+std::size_t{'0'}), C...>::type;
     };
 
     //! Base case with no quotient
@@ -71,7 +71,7 @@ namespace cereal
     template <size_t R, char ... C>
     struct to_string_impl<0, R, C...>
     {
-      using type = char_seq_to_c_str<R+'0', C...>;
+      using type = char_seq_to_c_str<static_cast<char>(R+std::size_t{'0'}), C...>;
     };
 
     //! Generates a c string for a given index of a tuple
@@ -84,7 +84,7 @@ namespace cereal
     struct tuple_element_name
     {
       using type = typename to_string_impl<T/10, T%10>::type;
-      static const typename type::arr_type c_str(){ return type::str; };
+      static const typename type::arr_type c_str(){ return type::str; }
     };
 
     // unwinds a tuple to save it
@@ -95,7 +95,7 @@ namespace cereal
       template <class Archive, class ... Types> inline
       static void apply( Archive & ar, std::tuple<Types...> & tuple )
       {
-        serialize<Height - 1>::template apply( ar, tuple );
+        serialize<Height - 1>:: apply( ar, tuple );
         ar( CEREAL_NVP_(tuple_element_name<Height - 1>::c_str(),
             std::get<Height - 1>( tuple )) );
       }
@@ -116,7 +116,7 @@ namespace cereal
   template <class Archive, class ... Types> inline
   void CEREAL_SERIALIZE_FUNCTION_NAME( Archive & ar, std::tuple<Types...> & tuple )
   {
-    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply( ar, tuple );
+    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::apply( ar, tuple );
   }
 } // namespace cereal
 


### PR DESCRIPTION
Due to enforcement of:
https://cplusplus.github.io/CWG/issues/96.html
more strictly within Clang-19, the template syntax for cereal within includecereal/types/tuple.hpp is broken.

The issue can be found here and has been merged to cereal:
https://github.com/USCiLab/cereal/commit/d81e2f7df7b334fee057e53017388d02e555a836

I have updated the neuroh5 repo to use cereals latest tuple.hpp changes and can build successfully on clang-19 and gcc

If you would like me to only change the template syntax in lines 98 and 119 please let me know and I can edit the PR
