### PR TITLE
Fix new_compiler() TypeError with setuptools >= 72

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os, sys, math, subprocess, platform, sysconfig
 import multiprocessing
 from setuptools import setup
 from setuptools.extension import Extension
-from distutils.command import build_ext
+from setuptools.command import build_ext
 
 cmake_cmd_args = []
 for f in sys.argv:

--- a/setup.py.tmpl
+++ b/setup.py.tmpl
@@ -2,8 +2,9 @@
 import os, sys, subprocess, platform
 import mpi4py
 import numpy as np
-from distutils.core import setup, Extension
-from distutils.command import build_ext
+from setuptools import setup
+from setuptools.extension import Extension
+from setuptools.command import build_ext
 from os.path import exists, abspath, dirname, join
 
 cmake_cmd_args = []


### PR DESCRIPTION
setuptools >= 72 removed the dry_run, verbose, and force keyword arguments from new_compiler(); the fix is a one-line change from distutils.command to setuptools.command, which provides the updated build_ext.run()