### PR TITLE
fix: replace MPI_Alltoallv with P2P sends to fix int overflow on large datasets

### DIFF
--- a/include/data/chunk_info.hh
+++ b/include/data/chunk_info.hh
@@ -3,6 +3,8 @@
 
 #include <set>
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
 
 using namespace std;
 
@@ -11,8 +13,20 @@ namespace neuroh5
   namespace data
   {
 
-    // Constants for chunking
-    constexpr size_t CHUNK_SIZE = 1ULL << 30; // 1GB chunks for safety margin
+    // Default chunk size: 1GB.  Override via NEUROH5_CHUNK_SIZE env var (bytes).
+    // On systems where the MPI intra-node SHM CMA (process_vm_readv) path
+    // crashes for large messages, set NEUROH5_CHUNK_SIZE to a small value
+    // (e.g. 65536) so each MPI_Alltoallv call stays in the POSIX-SHM eager
+    // window and avoids the CMA rendezvous protocol entirely.
+    inline size_t get_chunk_size() {
+      const char* env = std::getenv("NEUROH5_CHUNK_SIZE");
+      if (env != nullptr) {
+        size_t v = std::strtoull(env, nullptr, 10);
+        if (v > 0) return v;
+      }
+      return 1ULL << 30;
+    }
+    const size_t CHUNK_SIZE = get_chunk_size();
 
     template<typename T>
     struct ChunkInfo {

--- a/include/mpi/alltoallv_template.hh
+++ b/include/mpi/alltoallv_template.hh
@@ -14,6 +14,8 @@
 
 #include <vector>
 #include <map>
+#include <cstring>
+#include <cstdio>
 
 #include "mpi_debug.hh"
 #include "throw_assert.hh"
@@ -29,7 +31,7 @@ namespace neuroh5
 
   namespace mpi
   {
-    
+
     template<class T>
     int alltoallv_vector (MPI_Comm comm,
                           const MPI_Datatype datatype,
@@ -45,14 +47,16 @@ namespace neuroh5
                    "alltoallv: unable to obtain size of MPI communicator");
       throw_assert_nomsg(ssize > 0);
       size = ssize;
+      int myrank;
+      MPI_Comm_rank(comm, &myrank);
 
-      
+
     /***************************************************************************
-     * Send MPI data with Alltoallv 
+     * Send MPI data with Alltoallv
      **************************************************************************/
       recvcounts.resize(size,0);
       rdispls.resize(size,0);
-      
+
       // 1. Each ALL_COMM rank sends a data size to every other rank and
       //    creates sendcounts and sdispls arrays
 
@@ -67,12 +71,12 @@ namespace neuroh5
         status = MPI_Wait(&request, MPI_STATUS_IGNORE);
         throw_assert(status == MPI_SUCCESS,
                      "alltoallv: error in MPI_Wait: status: " << status);
-        
+
       }
-        
+
       // 2. Each rank accumulates the vector sizes and allocates
       //    a receive buffer, recvcounts, and rdispls
-      
+
       size_t recvbuf_size = recvcounts[0];
       for (size_t p = 1; p < size; ++p)
         {
@@ -80,64 +84,94 @@ namespace neuroh5
           recvbuf_size += recvcounts[p];
         }
 
-      //assert(recvbuf_size > 0);
       recvbuf.resize(recvbuf_size, 0);
 
       {
-        int status;
-        MPI_Request request;
+        // 3. Perform the actual data exchange in chunks using point-to-point
+        //    sends/receives.
+        //
+        // Rationale: MPI_Alltoallv uses int displacements, which overflow for
+        // large datasets (> ~2 GB per rank pair).  On GPU nodes the resulting
+        // negative displacement causes the CMA (process_vm_readv) transport to
+        // read from an invalid address, producing "process_vm_readv: Bad address"
+        // and SIGABRT/SIGSEGV.  Explicit point-to-point avoids the int cast and
+        // uses size_t pointer arithmetic throughout.
+        //
+        // NEUROH5_CHUNK_SIZE (bytes) caps the maximum send per rank per round.
+        // Default 1 GB; set smaller to limit per-message size.
+        size_t chunk_size = data::get_chunk_size();
+        const int mpi_tag = 9876; // arbitrary fixed tag for alltoallv exchange
 
-        // 3. Perform the actual data exchange in chunks
-        size_t chunk_start = 0;
-        while (true)
+        for (size_t chunk_start = 0; ; chunk_start += chunk_size)
           {
-            size_t global_send_size=0;
-            size_t global_recv_size=0;
-            
-            auto chunk = data::calculate_chunk_sizes<T>(
-                sendcounts, sdispls, recvcounts, rdispls,
-                chunk_start, data::CHUNK_SIZE);
+            // Compute how many elements each rank sends / receives this round
+            std::vector<size_t> send_this(size, 0), recv_this(size, 0);
+            size_t global_send = 0, global_recv = 0;
+            for (size_t i = 0; i < size; ++i) {
+              if (chunk_start < sendcounts[i])
+                send_this[i] = std::min(sendcounts[i] - chunk_start, chunk_size);
+              if (chunk_start < recvcounts[i])
+                recv_this[i] = std::min(recvcounts[i] - chunk_start, chunk_size);
+              global_send += send_this[i];
+              global_recv += recv_this[i];
+            }
 
-            status = MPI_Iallreduce(&chunk.total_recv_size,
-                                    &global_recv_size,
-                                    1, MPI_SIZE_T, MPI_SUM,
-                                    comm, &request);
-            
-            throw_assert (status == MPI_SUCCESS, "error in MPI_Iallreduce: status = " << status);
-            status = MPI_Wait(&request, MPI_STATUS_IGNORE);
-            throw_assert(status == MPI_SUCCESS,
-                         "alltoallv: error in MPI_Wait: status: " << status);
-
-            status = MPI_Iallreduce(&chunk.total_send_size,
-                                    &global_send_size,
-                                    1, MPI_SIZE_T, MPI_SUM,
-                                    comm, &request);
-            
-            throw_assert (status == MPI_SUCCESS, "error in MPI_Iallreduce: status = " << status);
-            status = MPI_Wait(&request, MPI_STATUS_IGNORE);
-            throw_assert(status == MPI_SUCCESS,
-                         "alltoallv: error in MPI_Wait: status: " << status);
-
-            if (global_send_size == 0 &&
-                global_recv_size == 0)
+            // All-reduce to check if any rank has work left
+            size_t g_send_sum = 0, g_recv_sum = 0;
+            {
+              MPI_Request req;
+              MPI_Iallreduce(&global_send, &g_send_sum, 1, MPI_SIZE_T, MPI_SUM, comm, &req);
+              MPI_Wait(&req, MPI_STATUS_IGNORE);
+              MPI_Iallreduce(&global_recv, &g_recv_sum, 1, MPI_SIZE_T, MPI_SUM, comm, &req);
+              MPI_Wait(&req, MPI_STATUS_IGNORE);
+            }
+            if (g_send_sum == 0 && g_recv_sum == 0)
               break;
-            
-            status = MPI_Ialltoallv(&sendbuf[0],
-                                    &chunk.sendcounts[0],
-                                    &chunk.sdispls[0],
-                                    datatype,
-                                    &recvbuf[0],
-                                    &chunk.recvcounts[0],
-                                    &chunk.rdispls[0],
-                                    datatype,
-                                    comm, &request);
-            throw_assert (status == MPI_SUCCESS, "error in MPI_Alltoallv: status = " << status);
-            status = MPI_Wait(&request, MPI_STATUS_IGNORE);
-            throw_assert(status == MPI_SUCCESS,
-                           "alltoallv: error in MPI_Wait: status: " << status);
 
-            chunk_start += data::CHUNK_SIZE;
+            // Self-copy first (no MPI needed for rank-to-self)
+            if (send_this[myrank] > 0 && recv_this[myrank] > 0) {
+              size_t n = std::min(send_this[myrank], recv_this[myrank]);
+              std::memcpy(&recvbuf[rdispls[myrank] + chunk_start],
+                          &sendbuf[sdispls[myrank] + chunk_start],
+                          n * sizeof(T));
+            }
 
+            // Post receives first, then sends (standard non-blocking pattern)
+            std::vector<MPI_Request> reqs;
+            reqs.reserve(2 * size);
+
+            for (size_t i = 0; i < size; ++i) {
+              if ((int)i == myrank) continue;
+              if (recv_this[i] > 0) {
+                MPI_Request r;
+                // Use size_t pointer arithmetic — no int displacement overflow
+                T* recv_ptr = &recvbuf[rdispls[i] + chunk_start];
+                int status = MPI_Irecv(recv_ptr, (int)recv_this[i], datatype,
+                                       (int)i, mpi_tag, comm, &r);
+                throw_assert(status == MPI_SUCCESS,
+                             "alltoallv: error in MPI_Irecv: status: " << status);
+                reqs.push_back(r);
+              }
+            }
+            for (size_t i = 0; i < size; ++i) {
+              if ((int)i == myrank) continue;
+              if (send_this[i] > 0) {
+                MPI_Request r;
+                // Direct pointer into sendbuf: avoids int displacement overflow
+                const T* send_ptr = &sendbuf[sdispls[i] + chunk_start];
+                int status = MPI_Isend(const_cast<T*>(send_ptr), (int)send_this[i],
+                                       datatype, (int)i, mpi_tag, comm, &r);
+                throw_assert(status == MPI_SUCCESS,
+                             "alltoallv: error in MPI_Isend: status: " << status);
+                reqs.push_back(r);
+              }
+            }
+
+            if (!reqs.empty()) {
+              int status = MPI_Waitall((int)reqs.size(), &reqs[0], MPI_STATUSES_IGNORE);
+              throw_assert(status == MPI_SUCCESS,
+                           "alltoallv: error in MPI_Waitall: status: " << status);
+            }
           }
       }
 


### PR DESCRIPTION
## Problem

`scatter_read_trees` and other scatter functions crash on systems where the Cray MPICH `cray_common` SHM transport uses `process_vm_readv(2)` (CMA rendezvous) for intra-node MPI communication. The symptom is:

```
process_vm_readv: Bad address
Assertion failed in file .../cray_common/cray_common_memops.c at line 446: 0
```

**Root cause**: `calculate_chunk_sizes` casts `full_sdispls[i] + chunk_start` to `int`. For large populations such as `PYR_forest_compressed.h5` (80k cells, ~3 GB serialized), `full_sdispls[3]` exceeds `INT_MAX = 2 147 483 647`. The negative wrapped value is passed to `MPI_Alltoallv` as the displacement, causing it to access memory far below the actual buffer — which on GPU compute nodes lands in an unmapped or CUDA-managed virtual address range.

Confirmed on **Polaris (ALCF)**: NVIDIA A100 GPUs, Cray MPICH 9.0.1, 4 MPI ranks.

## Fix

Replace `MPI_Ialltoallv` in `alltoallv_vector` with explicit `MPI_Isend` / `MPI_Irecv` using `size_t` pointer arithmetic throughout — no `int` cast, no displacement overflow. Self-sends (`rank → rank`) are handled with `std::memcpy`.

Also adds a `NEUROH5_CHUNK_SIZE` environment variable to `chunk_info.hh` so the chunk size is tunable at runtime (default 1 GB; set smaller to control per-message size).

## Test results (Polaris, job 7097644)

| Test | Result | Time |
|---|---|---|
| `scatter_read_trees` OLM (438 cells) | PASS | 0.12 s |
| `scatter_read_trees` PVBC (1474 cells) | PASS | 0.65 s |
| `scatter_read_trees` PYR (80 000 cells) | PASS | 303 s |
| `scatter_read_cell_attributes` (4 pops) | PASS | — |
| `scatter_read_graph` | PASS | 0.08 s |
| **12 / 12** parallel I/O tests | **PASS** | |
