### PR TITLE
fix: skip gids not in local partition in append_rank_attr_map

### DIFF
--- a/src/data/append_rank_attr_map.cc
+++ b/src/data/append_rank_attr_map.cc
@@ -49,8 +49,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<float> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];
@@ -67,8 +66,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<uint8_t> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];
@@ -85,8 +83,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<int8_t> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];
@@ -103,8 +100,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<uint16_t> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];
@@ -121,8 +117,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<int16_t> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];
@@ -139,8 +134,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<uint32_t> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];
@@ -157,8 +151,7 @@ namespace neuroh5
               const CELL_IDX_T index = element.first;
               const deque<int32_t> &v = element.second;
               auto it = node_rank_map.find(index);
-              throw_assert(it != node_rank_map.end(),
-                           "append_rank_attr_map: index not found in node rank map");
+              if (it == node_rank_map.end()) continue; // gid not in local partition
 	      for (const rank_t& dst_rank : it->second)
 		{
 		  data::AttrMap &attr_map = rank_attr_map[dst_rank];


### PR DESCRIPTION
## Problem

When the spike input file covers a superset of the circuit being simulated — for example, a 1000-cell STIM input file used with a 10-cell Small circuit — gids outside the local rank partition appear in `attr_values` but not in `node_rank_map`. The previous `throw_assert` fired on every such gid, crashing the process during output writing:

```
Assertion 'it != node_rank_map.end()' failed in
  src/data/append_rank_attr_map.cc line 53
terminate called after throwing an instance of 'AssertionFailureException'
```

Reproducible on every simulation run with MiV-Simulator Microcircuit_Small on Polaris (NVIDIA A100, Cray MPICH 9.0.1).

## Fix

Replace the assertion with `continue` in all 7 type loops (float, int8, uint8, uint16, int16, uint32, int32), so gids absent from the local partition are silently skipped.

This matches the behaviour already used in other neuroh5 read paths and is the correct semantics: a rank is only responsible for the gids in its own partition.

## Testing

Verified on Polaris (PBS 7161529 → 7163402): MiV-Simulator Microcircuit_Small simulation completes without assertion failures after neuroh5 rebuild with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)