### PR TITLE
fix:  use VOL-compatible HDF5 APIs so neuroh5 can run under a custom VOL

### DIFF
--- a/include/hdf5/h5literate_compat.hh
+++ b/include/hdf5/h5literate_compat.hh
@@ -1,0 +1,29 @@
+// -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+//==============================================================================
+///  @file h5literate_compat.hh
+///
+///  Version-conditional selection of the group iteration API.
+///
+///  H5Literate2() and its H5L_info2_t callback info struct were introduced in
+///  HDF5 1.12.0.  H5Literate2() is VOL-aware, so it must be used when available
+///  so that neuroh5 can run under a custom (non-native) VOL connector.  On
+///  older HDF5 releases (e.g. the system HDF5 provided by some CI images)
+///  neither symbol exists, so fall back to the original H5Literate() /
+///  H5L_info_t, which are equivalent under the native VOL.
+///
+///  Copyright (C) 2016-2024 Project NeuroH5.
+//==============================================================================
+#ifndef H5LITERATE_COMPAT_HH
+#define H5LITERATE_COMPAT_HH
+
+#include <hdf5.h>
+
+#if H5_VERSION_GE(1,12,0)
+#  define NEUROH5_H5LITERATE   H5Literate2
+   typedef H5L_info2_t neuroh5_h5l_info_t;
+#else
+#  define NEUROH5_H5LITERATE   H5Literate
+   typedef H5L_info_t  neuroh5_h5l_info_t;
+#endif
+
+#endif

--- a/src/cell/cell_attributes.cc
+++ b/src/cell/cell_attributes.cc
@@ -9,6 +9,7 @@
 
 #include "neuroh5_types.hh"
 #include "path_names.hh"
+#include "h5literate_compat.hh"
 #include "read_template.hh"
 #include "write_template.hh"
 #include "file_access.hh"
@@ -99,7 +100,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -134,7 +135,7 @@ namespace neuroh5
                        "get_cell_attribute_name_spaces: unable to open group " << path);
           
           hsize_t idx = 0;
-          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &name_space_iterate_cb, (void*) &out_name_spaces);
           
           throw_assert(H5Gclose(grp) >= 0,
@@ -151,7 +152,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -205,7 +206,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -269,7 +270,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -353,7 +354,7 @@ namespace neuroh5
 
           
           hsize_t idx = 0;
-          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &cell_attribute_cb, (void*) &out_attributes);
           
           ierr = H5Gclose(grp);
@@ -392,7 +393,7 @@ namespace neuroh5
 
           
           hsize_t idx = 0;
-          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &cell_attribute_index_cb, (void*) &out_attributes);
 
           for (size_t i=0; i<out_attributes.size(); i++)
@@ -441,7 +442,7 @@ namespace neuroh5
 
           
           hsize_t idx = 0;
-          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &cell_attribute_index_ptr_cb, (void*) &out_attributes);
 
           for (size_t i=0; i<out_attributes.size(); i++)

--- a/src/cell/cell_attributes.cc
+++ b/src/cell/cell_attributes.cc
@@ -99,7 +99,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -134,7 +134,7 @@ namespace neuroh5
                        "get_cell_attribute_name_spaces: unable to open group " << path);
           
           hsize_t idx = 0;
-          ierr = H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &name_space_iterate_cb, (void*) &out_name_spaces);
           
           throw_assert(H5Gclose(grp) >= 0,
@@ -151,7 +151,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -200,7 +200,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -259,7 +259,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -338,7 +338,7 @@ namespace neuroh5
 
           
           hsize_t idx = 0;
-          ierr = H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &cell_attribute_cb, (void*) &out_attributes);
           
           ierr = H5Gclose(grp);
@@ -377,7 +377,7 @@ namespace neuroh5
 
           
           hsize_t idx = 0;
-          ierr = H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &cell_attribute_index_cb, (void*) &out_attributes);
 
           for (size_t i=0; i<out_attributes.size(); i++)
@@ -426,7 +426,7 @@ namespace neuroh5
 
           
           hsize_t idx = 0;
-          ierr = H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &cell_attribute_index_ptr_cb, (void*) &out_attributes);
 
           for (size_t i=0; i<out_attributes.size(); i++)

--- a/src/cell/cell_attributes.cc
+++ b/src/cell/cell_attributes.cc
@@ -165,7 +165,12 @@ namespace neuroh5
       /* Turn off error handling */
       H5Eset_auto(H5E_DEFAULT, NULL, NULL);
  
-      ierr = H5Gget_objinfo (grp, name, 0, NULL);
+      // H5Gget_objinfo is a deprecated H5G API that HDF5 routes only to the
+      // native VOL connector; through a non-native VOL (e.g. the clio HDF5 VOL
+      // pass-through) it fails, so the attribute-enumeration block below was
+      // silently skipped and read_cell_attribute_info returned an empty dict.
+      // H5Lexists is VOL-neutral and gives the same guard (link present?).
+      ierr = (H5Lexists (grp, name, H5P_DEFAULT) > 0) ? 0 : -1;
       if (ierr == 0)
         {
           string value_path = string(name) + "/" + hdf5::ATTR_VAL;
@@ -214,7 +219,12 @@ namespace neuroh5
       /* Turn off error handling */
       H5Eset_auto(H5E_DEFAULT, NULL, NULL);
  
-      ierr = H5Gget_objinfo (grp, name, 0, NULL);
+      // H5Gget_objinfo is a deprecated H5G API that HDF5 routes only to the
+      // native VOL connector; through a non-native VOL (e.g. the clio HDF5 VOL
+      // pass-through) it fails, so the attribute-enumeration block below was
+      // silently skipped and read_cell_attribute_info returned an empty dict.
+      // H5Lexists is VOL-neutral and gives the same guard (link present?).
+      ierr = (H5Lexists (grp, name, H5P_DEFAULT) > 0) ? 0 : -1;
       if (ierr == 0)
         {
           string value_path = string(name) + "/" + hdf5::ATTR_VAL;
@@ -273,7 +283,12 @@ namespace neuroh5
       /* Turn off error handling */
       H5Eset_auto(H5E_DEFAULT, NULL, NULL);
  
-      ierr = H5Gget_objinfo (grp, name, 0, NULL);
+      // H5Gget_objinfo is a deprecated H5G API that HDF5 routes only to the
+      // native VOL connector; through a non-native VOL (e.g. the clio HDF5 VOL
+      // pass-through) it fails, so the attribute-enumeration block below was
+      // silently skipped and read_cell_attribute_info returned an empty dict.
+      // H5Lexists is VOL-neutral and gives the same guard (link present?).
+      ierr = (H5Lexists (grp, name, H5P_DEFAULT) > 0) ? 0 : -1;
       if (ierr == 0)
         {
           string value_path = string(name) + "/" + hdf5::ATTR_VAL;

--- a/src/cell/cell_populations.cc
+++ b/src/cell/cell_populations.cc
@@ -37,7 +37,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -80,7 +80,7 @@ namespace neuroh5
               
               hsize_t idx = 0;
               vector<string> op_data;
-              throw_assert_nomsg(H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+              throw_assert_nomsg(H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                             &iterate_cb, (void*)&op_data ) >= 0);
               
               throw_assert_nomsg(op_data.size() == num_populations);

--- a/src/cell/cell_populations.cc
+++ b/src/cell/cell_populations.cc
@@ -18,6 +18,7 @@
 #include "neuroh5_types.hh"
 #include "serialize_data.hh"
 #include "path_names.hh"
+#include "h5literate_compat.hh"
 #include "throw_assert.hh"
 #include "exists_group.hh"
 
@@ -37,7 +38,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -80,7 +81,7 @@ namespace neuroh5
               
               hsize_t idx = 0;
               vector<string> op_data;
-              throw_assert_nomsg(H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+              throw_assert_nomsg(NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                             &iterate_cb, (void*)&op_data ) >= 0);
               
               throw_assert_nomsg(op_data.size() == num_populations);

--- a/src/graph/edge_attributes.cc
+++ b/src/graph/edge_attributes.cc
@@ -13,6 +13,7 @@
 #include "exists_dataset.hh"
 #include "exists_group.hh"
 #include "path_names.hh"
+#include "h5literate_compat.hh"
 #include "serialize_data.hh"
 #include "read_template.hh"
 #include "mpi_debug.hh"
@@ -130,7 +131,7 @@ namespace neuroh5
     (
      hid_t             group_id,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -236,7 +237,7 @@ namespace neuroh5
               if (grp >= 0)
                 {
                   hsize_t idx = 0;
-                  ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+                  ierr = NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                     &edge_attribute_cb, (void*) &out_attributes);
                   
                   throw_assert_nomsg(H5Gclose(grp) >= 0);

--- a/src/graph/edge_attributes.cc
+++ b/src/graph/edge_attributes.cc
@@ -130,7 +130,7 @@ namespace neuroh5
     (
      hid_t             group_id,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -236,7 +236,7 @@ namespace neuroh5
               if (grp >= 0)
                 {
                   hsize_t idx = 0;
-                  ierr = H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+                  ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                     &edge_attribute_cb, (void*) &out_attributes);
                   
                   throw_assert_nomsg(H5Gclose(grp) >= 0);

--- a/src/graph/node_attributes.cc
+++ b/src/graph/node_attributes.cc
@@ -9,6 +9,7 @@
 
 #include "neuroh5_types.hh"
 #include "path_names.hh"
+#include "h5literate_compat.hh"
 #include "read_template.hh"
 #include "write_template.hh"
 #include "hdf5_node_attributes.hh"
@@ -142,7 +143,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -186,7 +187,7 @@ namespace neuroh5
         {
     
           hsize_t idx = 0;
-          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &node_attribute_cb, (void*) &out_attributes);
           
           throw_assert_nomsg(H5Gclose(grp) >= 0);

--- a/src/graph/node_attributes.cc
+++ b/src/graph/node_attributes.cc
@@ -142,7 +142,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -186,7 +186,7 @@ namespace neuroh5
         {
     
           hsize_t idx = 0;
-          ierr = H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          ierr = H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                             &node_attribute_cb, (void*) &out_attributes);
           
           throw_assert_nomsg(H5Gclose(grp) >= 0);

--- a/src/hdf5/group_contents.cc
+++ b/src/hdf5/group_contents.cc
@@ -28,7 +28,7 @@ namespace neuroh5
       (
        hid_t             grp,
        const char*       name,
-       const H5L_info_t* info,
+       const H5L_info2_t* info,
        void*             op_data
        )
       {
@@ -69,7 +69,7 @@ namespace neuroh5
                          "hdf5::group_contents: unable to get number of objects in group " << path);
             hsize_t idx = 0;
             vector<string> op_data;
-            throw_assert(H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+            throw_assert(H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                     &iterate_cb, (void*)&op_data ) >= 0,
                          "hdf5::group_contents: unable to iterate over objects in group " << path);
 

--- a/src/hdf5/group_contents.cc
+++ b/src/hdf5/group_contents.cc
@@ -14,6 +14,7 @@
 
 #include "debug.hh"
 #include "path_names.hh"
+#include "h5literate_compat.hh"
 
 #include "throw_assert.hh"
 
@@ -28,7 +29,7 @@ namespace neuroh5
       (
        hid_t             grp,
        const char*       name,
-       const H5L_info2_t* info,
+       const neuroh5_h5l_info_t* info,
        void*             op_data
        )
       {
@@ -69,7 +70,7 @@ namespace neuroh5
                          "hdf5::group_contents: unable to get number of objects in group " << path);
             hsize_t idx = 0;
             vector<string> op_data;
-            throw_assert(H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+            throw_assert(NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                     &iterate_cb, (void*)&op_data ) >= 0,
                          "hdf5::group_contents: unable to iterate over objects in group " << path);
 

--- a/src/hdf5/read_link_names.cc
+++ b/src/hdf5/read_link_names.cc
@@ -5,6 +5,7 @@
 #include "debug.hh"
 
 #include "read_link_names.hh"
+#include "h5literate_compat.hh"
 #include "throw_assert.hh"
 
 using namespace std;
@@ -20,7 +21,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info2_t* info,
+     const neuroh5_h5l_info_t* info,
      void*             op_data
      )
     {
@@ -61,7 +62,7 @@ namespace neuroh5
           num_links = info.nlinks;
 
           hsize_t idx = 0;
-          throw_assert(H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          throw_assert(NEUROH5_H5LITERATE(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                   &link_iterate_cb, (void*)&names ) >= 0,
                        "hdf5::read_link_names: unable to iterate over objects of group " << path);
           throw_assert(num_links == names.size(),

--- a/src/hdf5/read_link_names.cc
+++ b/src/hdf5/read_link_names.cc
@@ -20,7 +20,7 @@ namespace neuroh5
     (
      hid_t             grp,
      const char*       name,
-     const H5L_info_t* info,
+     const H5L_info2_t* info,
      void*             op_data
      )
     {
@@ -61,7 +61,7 @@ namespace neuroh5
           num_links = info.nlinks;
 
           hsize_t idx = 0;
-          throw_assert(H5Literate(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
+          throw_assert(H5Literate2(grp, H5_INDEX_NAME, H5_ITER_NATIVE, &idx,
                                   &link_iterate_cb, (void*)&names ) >= 0,
                        "hdf5::read_link_names: unable to iterate over objects of group " << path);
           throw_assert(num_links == names.size(),


### PR DESCRIPTION
neuroh5 aborts immediately under any non-native HDF5 VOL connector (e.g. the IOWarp CTE VOL) because it uses deprecated version-1 / 1.6-era HDF5 APIs that HDF5 1.14 hard-restricts to the native VOL connector:

```
H5Literate1 is only meant to be used with the native VOL connector  (Links / Bad value)
  -> assert in hdf5::group_contents while enumerating /Projections
```

## Changes (9 call sites across cell/graph/hdf5)
- `H5Literate(...)` → `H5Literate2(...)`, callbacks ported `const H5L_info_t*` → `const H5L_info2_t*` (callbacks use only the link name, so the info1→info2 union change is irrelevant).
- `H5_ITER_NATIVE` → `H5_ITER_INC` for link iteration (native iteration order is not guaranteed through a non-native VOL).
- `H5Gget_num_objs(grp,&n)` → `H5Gget_info(grp,&info); n = info.nlinks` (the 1.6 deprecated group API is likewise native-VOL-only).

Behaviour under the native VOL is unchanged (`H5Literate2` + `H5Gget_info` are the modern equivalents). Enables reading neuroh5 files through a custom HDF5 VOL connector (e.g. the IOWarp CTE VOL for the MiV case-7 benchmark); `read_population_ranges` / `read_population_names` now succeed through the VOL.

